### PR TITLE
Feat/chat/three-choices : Add question creation endpoint

### DIFF
--- a/src/main/java/com/server/bearmurderermulti/controller/QuestionController.java
+++ b/src/main/java/com/server/bearmurderermulti/controller/QuestionController.java
@@ -1,0 +1,35 @@
+package com.server.bearmurderermulti.controller;
+
+import com.server.bearmurderermulti.domain.dto.question.QuestionCreateRequest;
+import com.server.bearmurderermulti.domain.dto.question.QuestionCreateResponse;
+import com.server.bearmurderermulti.domain.entity.Member;
+import com.server.bearmurderermulti.exception.Response;
+import com.server.bearmurderermulti.service.CustomUserDetails;
+import com.server.bearmurderermulti.service.QuestionService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/question")
+@RequiredArgsConstructor
+@Slf4j
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @PostMapping("/create")
+    public Response<QuestionCreateResponse> createQuestion(@RequestBody QuestionCreateRequest request, @AuthenticationPrincipal CustomUserDetails customUserDetails, HttpServletRequest httpServletRequest) {
+
+        Member loginMember = customUserDetails.getMember();
+
+        QuestionCreateResponse response = questionService.createQuestion(loginMember, request, httpServletRequest);
+        return Response.success(response);
+
+    }
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/question/AIQuestionCreateRequest.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/question/AIQuestionCreateRequest.java
@@ -1,0 +1,27 @@
+package com.server.bearmurderermulti.domain.dto.question;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AIQuestionCreateRequest {
+
+    private Long gameNo;
+    private String npcName;
+    private String keyWord;
+    private String keyWordType;
+
+    public static AIQuestionCreateRequest from(QuestionCreateRequest request) {
+        return new AIQuestionCreateRequest(
+                request.getGameSetNo(),
+                request.getNpcName(),
+                request.getKeyWord(),
+                request.getKeyWordType()
+        );
+    }
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/question/QuestionCreateDTO.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/question/QuestionCreateDTO.java
@@ -1,0 +1,31 @@
+package com.server.bearmurderermulti.domain.dto.question;
+
+import com.server.bearmurderermulti.domain.entity.GameSet;
+import com.server.bearmurderermulti.domain.entity.Question;
+import com.server.bearmurderermulti.domain.enum_class.KeyWordType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionCreateDTO {
+
+    private Integer number;
+    private String question;
+
+    public static Question toEntity(QuestionCreateDTO dto, GameSet gameSet, QuestionCreateRequest request) {
+        return Question.builder()
+                .npcName(request.getNpcName())
+                .keyWord(request.getKeyWord())
+                .keyWordType(KeyWordType.valueOf(request.getKeyWordType().toUpperCase()))
+                .gameSet(gameSet)
+                .questionNumber(dto.getNumber())
+                .questionText(dto.getQuestion())
+                .build();
+    }
+
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/question/QuestionCreateRequest.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/question/QuestionCreateRequest.java
@@ -1,0 +1,29 @@
+package com.server.bearmurderermulti.domain.dto.question;
+
+import com.server.bearmurderermulti.domain.entity.GameSet;
+import com.server.bearmurderermulti.domain.entity.Question;
+import com.server.bearmurderermulti.domain.enum_class.KeyWordType;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionCreateRequest {
+
+    private Long gameSetNo;
+    private String npcName;
+    private String keyWord;
+    private String keyWordType;
+
+    public static Question toEntity(QuestionCreateRequest request, KeyWordType keyWordType, GameSet gameSet) {
+        return Question.builder()
+                .npcName(request.npcName)
+                .keyWord(request.keyWord)
+                .keyWordType(keyWordType)
+                .gameSet(gameSet)
+                .build();
+    }
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/question/QuestionCreateResponse.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/question/QuestionCreateResponse.java
@@ -1,0 +1,22 @@
+package com.server.bearmurderermulti.domain.dto.question;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuestionCreateResponse {
+
+    private List<QuestionCreateDTO> questions;
+
+    public static QuestionCreateResponse from(QuestionCreateResponse response) {
+        return new QuestionCreateResponse(response.getQuestions());
+    }
+
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/entity/Question.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/entity/Question.java
@@ -1,0 +1,37 @@
+package com.server.bearmurderermulti.domain.entity;
+
+import com.server.bearmurderermulti.domain.enum_class.KeyWordType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+@Table(name = "question_tb")
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_no")
+    private Long questionNo;
+
+    private String npcName;
+
+    private String keyWord;
+
+    @Enumerated(EnumType.STRING)
+    private KeyWordType keyWordType;
+
+    @Column(name = "question_number")
+    private Integer questionNumber;
+
+    @Column(name = "question_text")
+    private String questionText;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "game_set_no")
+    private GameSet gameSet;
+
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/enum_class/KeyWordType.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/enum_class/KeyWordType.java
@@ -1,0 +1,6 @@
+package com.server.bearmurderermulti.domain.enum_class;
+
+public enum KeyWordType {
+
+    WEAPON, PLACE
+}

--- a/src/main/java/com/server/bearmurderermulti/repository/QuestionRepository.java
+++ b/src/main/java/com/server/bearmurderermulti/repository/QuestionRepository.java
@@ -1,0 +1,9 @@
+package com.server.bearmurderermulti.repository;
+
+import com.server.bearmurderermulti.domain.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/server/bearmurderermulti/service/QuestionService.java
+++ b/src/main/java/com/server/bearmurderermulti/service/QuestionService.java
@@ -1,0 +1,124 @@
+package com.server.bearmurderermulti.service;
+
+import com.server.bearmurderermulti.configuration.jwt.JwtProvider;
+import com.server.bearmurderermulti.domain.dto.question.AIQuestionCreateRequest;
+import com.server.bearmurderermulti.domain.dto.question.QuestionCreateDTO;
+import com.server.bearmurderermulti.domain.dto.question.QuestionCreateRequest;
+import com.server.bearmurderermulti.domain.dto.question.QuestionCreateResponse;
+import com.server.bearmurderermulti.domain.entity.GameSet;
+import com.server.bearmurderermulti.domain.entity.Member;
+import com.server.bearmurderermulti.domain.entity.Question;
+import com.server.bearmurderermulti.exception.AppException;
+import com.server.bearmurderermulti.exception.ErrorCode;
+import com.server.bearmurderermulti.repository.GameSetRepository;
+import com.server.bearmurderermulti.repository.QuestionRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+    private final GameSetRepository gameSetRepository;
+    private final JwtProvider jwtProvider;
+
+    @Value("${ai.url}")
+    private String aiUrl;
+
+    public QuestionCreateResponse createQuestion(Member loginMember, QuestionCreateRequest request, HttpServletRequest httpServletRequest) {
+
+        log.info("🐻Question Save 시작");
+
+        String authHeader = httpServletRequest.getHeader("Authorization");
+
+        // 요청에서 받은 Authorization 헤더 출력
+        log.info("🐻Received Authorization header: {}", authHeader);
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 토큰 부분만 출력
+        String token = authHeader.substring(7);
+        log.info("🐻Extracted token: {}", token);
+
+        if (loginMember == null) {
+            log.error("🐻loginMember is null");
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        } else {
+            if (loginMember.getNickname() == null) {
+                log.error("🐻loginMember nickname is null");
+                throw new AppException(ErrorCode.UNAUTHORIZED);
+            }
+        }
+
+        // 토큰 유효성 검사 결과 출력
+        boolean isValid = jwtProvider.validateToken(authHeader);
+        log.info("🐻Token validation result: {}", isValid);
+
+        if (!isValid) {
+            throw new AppException(ErrorCode.UNAUTHORIZED);
+        }
+
+        Optional<GameSet> optionalGameSet = gameSetRepository.findByGameSetNo(request.getGameSetNo());
+
+        if (optionalGameSet.isEmpty()) {
+            throw new AppException(ErrorCode.GAME_NOT_FOUND);
+        }
+
+        log.info("🐻user-npc Question unity 통신 완료");
+
+        try {
+            return sendAIServer(request);
+        } catch (Exception e) {
+            log.error("🐻AI 통신 실패 : ", e);
+            throw e;
+        }
+    }
+
+    public QuestionCreateResponse sendAIServer(QuestionCreateRequest request) {
+
+        String aiServerUrl = aiUrl + "/api/v2/in-game/generate-questions";
+        WebClient webClient = WebClient.builder().baseUrl(aiServerUrl).build();
+
+        GameSet gameSet = gameSetRepository.findByGameSetNo(request.getGameSetNo())
+                .orElseThrow(() -> new AppException(ErrorCode.GAME_SET_NOT_FOUND));
+
+        // AI 서버에 보낼 요청 객체 생성
+        AIQuestionCreateRequest aiQuestionSaveRequest = new AIQuestionCreateRequest();
+        aiQuestionSaveRequest.setGameNo(request.getGameSetNo());
+        aiQuestionSaveRequest.setNpcName(request.getNpcName());
+        aiQuestionSaveRequest.setKeyWord(request.getKeyWord());
+        aiQuestionSaveRequest.setKeyWordType(request.getKeyWordType());
+
+        // AI 서버로 요청
+        QuestionCreateResponse response = webClient.post()
+                .uri(aiServerUrl)
+                .bodyValue(aiQuestionSaveRequest)
+                .retrieve()
+                .bodyToMono(QuestionCreateResponse.class)
+                .onErrorResume(e -> {
+                    log.error("🐻AI 통신 실패 : ", e);
+                    throw new AppException(ErrorCode.AI_INTERNAL_SERVER_ERROR);
+                })
+                .block();
+
+        List<QuestionCreateDTO> questions = response.getQuestions();
+        for (QuestionCreateDTO saveDTO : questions) {
+            Question question = QuestionCreateDTO.toEntity(saveDTO, gameSet, request);
+            questionRepository.save(question);
+        }
+
+        return response;
+    }
+
+}


### PR DESCRIPTION
## 🌟(#7 ) user-npc 질문 생성 통신 코드 구현


## ✍️내용
- game_no, npc_name, keyword, keyword_type 전송
- ai에서 온 질문 3개 저장

## 📸스크린샷


## 🎈참고사항
