### PR TITLE
Bugfix/game/start-scenario : Build response with game scenario and NPC details

### DIFF
--- a/src/main/java/com/server/bearmurderermulti/controller/ScenarioController.java
+++ b/src/main/java/com/server/bearmurderermulti/controller/ScenarioController.java
@@ -54,7 +54,7 @@ public class ScenarioController {
 
         Member loginMember = customUserDetails.getMember();
 
-        IntroAndScenarioResponse response = scenarioService.makeIntroAndScenario(request.getIntroRequest(), request.getMakeScenarioRequest(), loginMember);
+        IntroAndScenarioResponse response = scenarioService.makeIntroAndScenario(request.getIntroRequest(), loginMember);
         return Response.success(response);
     }
 }

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/game/AIResponse.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/game/AIResponse.java
@@ -1,0 +1,32 @@
+package com.server.bearmurderermulti.domain.dto.game;
+
+import com.server.bearmurderermulti.domain.entity.GameScenario;
+import com.server.bearmurderermulti.domain.entity.GameSet;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AIResponse {
+
+    private Answer answer;
+
+    public GameScenario toEntity(GameSet gameSet) {
+        return GameScenario.builder()
+                .victim(this.answer.getVictim())
+                .crimeScene(this.answer.getCrimeScene())
+                .method(this.answer.getMethod())
+                .witness("")
+                .eyewitnessInformation("")
+                .dailySummary("")
+                .scenarioPromptToken(0)
+                .scenarioCompletionToken(0)
+                .gameSet(gameSet)
+                .build();
+    }
+
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/game/Answer.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/game/Answer.java
@@ -1,0 +1,18 @@
+package com.server.bearmurderermulti.domain.dto.game;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Answer {
+
+    private String victim;
+    private String crimeScene;
+    private String method;
+
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/FirstScenarioResponse.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/FirstScenarioResponse.java
@@ -1,0 +1,31 @@
+package com.server.bearmurderermulti.domain.dto.scenario;
+
+import com.server.bearmurderermulti.domain.dto.gameNpc.GameNpcDTO;
+import com.server.bearmurderermulti.domain.entity.GameScenario;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FirstScenarioResponse {
+
+    private String crimeScene;
+    private String method;
+    private String victim;
+    private List<GameNpcDTO> gameNpcList;
+
+    public static FirstScenarioResponse of(GameScenario savedGameScenario, List<GameNpcDTO> gameNpcList) {
+        FirstScenarioResponse response = new FirstScenarioResponse();
+        response.crimeScene = savedGameScenario.getCrimeScene();
+        response.method = savedGameScenario.getMethod();
+        response.victim = savedGameScenario.getVictim();
+        response.gameNpcList = gameNpcList;
+        return response;
+    }
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/IntroAndScenarioRequest.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/IntroAndScenarioRequest.java
@@ -12,6 +12,5 @@ import lombok.Setter;
 public class IntroAndScenarioRequest {
 
     private IntroRequest introRequest;
-    private MakeScenarioRequest makeScenarioRequest;
 
 }

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/IntroAndScenarioResponse.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/IntroAndScenarioResponse.java
@@ -12,6 +12,6 @@ import lombok.Setter;
 public class IntroAndScenarioResponse {
 
     private IntroAnswerDTO introAnswer;
-    private MakeScenarioResponse scenarioResponse;
+    private FirstScenarioResponse firstScenarioResponse;
 
 }

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/IntroRequest.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/scenario/IntroRequest.java
@@ -15,7 +15,5 @@ import java.util.List;
 public class IntroRequest {
 
     private Long gameSetNo;
-    private String secretKey;
-    private List<String> characters = new ArrayList<>();
 
 }

--- a/src/main/java/com/server/bearmurderermulti/repository/GameNpcRepository.java
+++ b/src/main/java/com/server/bearmurderermulti/repository/GameNpcRepository.java
@@ -31,4 +31,6 @@ public interface GameNpcRepository extends JpaRepository<GameNpc, Long> {
     List<GameNpc> findAllByNpcNameInAndGameSet_GameSetNo(List<String> npcNames, Long gameSetNo);
 
     Optional<GameNpc> findByGameNpcNoAndGameSet(Long gameNpcNo, GameSet gameSet);
+
+    Optional<GameNpc> findByGameSet_GameSetNoAndNpcName(Long gameSetNo, String npcName);
 }


### PR DESCRIPTION
## 🌟(#18 ) 게임 시작 시 ai로부터 사망 npc 받고 unity에게 전달


## ✍️내용
- 게임 시작 시점에 받은 사망 npc 저장 및 사망 처리
- makeIntroAndScenario 요청이 들어오면 전달
- Intro 수정 된 로직 적용

## 📸스크린샷


## 🎈참고사항
