### PR TITLE
BugFix/game/gameSet : Add dual-member support to GameSet entity

### DIFF
--- a/src/main/java/com/server/bearmurderermulti/controller/GameController.java
+++ b/src/main/java/com/server/bearmurderermulti/controller/GameController.java
@@ -36,9 +36,9 @@ public class GameController {
     }
 
     @PostMapping("/start")
-    public ResponseEntity<Response<StartGameResponse>> startGame(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ResponseEntity<Response<StartGameResponse>> startGame(@AuthenticationPrincipal CustomUserDetails customUserDetails, @RequestBody StartGameRequest request) {
         Member loginMember = customUserDetails.getMember();
-        StartGameResponse response = gameService.startGame(loginMember);
+        StartGameResponse response = gameService.startGame(loginMember, request);
         return ResponseEntity.ok().body(Response.success(response));
     }
 

--- a/src/main/java/com/server/bearmurderermulti/domain/dto/game/StartGameRequest.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/dto/game/StartGameRequest.java
@@ -1,0 +1,15 @@
+package com.server.bearmurderermulti.domain.dto.game;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StartGameRequest {
+
+    private String participantNickname;
+}

--- a/src/main/java/com/server/bearmurderermulti/domain/entity/GameSet.java
+++ b/src/main/java/com/server/bearmurderermulti/domain/entity/GameSet.java
@@ -38,8 +38,12 @@ public class GameSet extends BaseEntity {
     private String gameSummary;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_no")
-    private Member member;
+    @JoinColumn(name = "host_no")
+    private Member host;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_no")
+    private Member participant;
 
     public void updateGameToken(long gameToken) {
         this.gameToken = gameToken;

--- a/src/main/java/com/server/bearmurderermulti/repository/GameSetRepository.java
+++ b/src/main/java/com/server/bearmurderermulti/repository/GameSetRepository.java
@@ -12,13 +12,14 @@ import java.util.Optional;
 public interface GameSetRepository extends JpaRepository<GameSet, Long> {
 
     Optional<GameSet> findByGameSetNo(Long gameSetNo);
-    Optional<GameSet> findByGameSetNoAndMember(Long gameSetNo, Member member);
 
+    @Query("SELECT gs FROM GameSet gs WHERE gs.gameSetNo = :gameSetNo AND (gs.host = :member OR gs.participant = :member)")
+    Optional<GameSet> findByGameSetNoAndMember(@Param("gameSetNo") Long gameSetNo, @Param("member") Member member);
 
-    @Query("SELECT gs FROM GameSet gs JOIN FETCH gs.member m WHERE m = :member AND gs.gameStatus <> 'GAME_END'")
+    @Query("SELECT gs FROM GameSet gs JOIN FETCH gs.host h LEFT JOIN FETCH gs.participant p WHERE (h = :member OR p = :member) AND gs.gameStatus <> 'GAME_END'")
     List<GameSet> findGameSetsByMember(@Param("member") Member member);
 
-    @Query("SELECT gs FROM GameSet gs JOIN FETCH gs.member m WHERE m = :member AND gs.gameSetNo = :gameSetNo AND gs.gameStatus = 'GAME_END'")
+    @Query("SELECT gs FROM GameSet gs JOIN FETCH gs.host h LEFT JOIN FETCH gs.participant p WHERE (h = :member OR p = :member) AND gs.gameSetNo = :gameSetNo AND gs.gameStatus = 'GAME_END'")
     Optional<GameSet> findEndedGameSetByMemberAndGameSetNo(@Param("gameSetNo") Long gameSetNo, @Param("member") Member member);
 
 

--- a/src/main/java/com/server/bearmurderermulti/service/GameService.java
+++ b/src/main/java/com/server/bearmurderermulti/service/GameService.java
@@ -123,7 +123,7 @@ public class GameService {
 
 
     @Transactional
-    public StartGameResponse startGame(Member loginMember) {
+    public StartGameResponse startGame(Member loginMember, StartGameRequest request) {
 
         log.info("🐻Game Start 시작");
 
@@ -137,6 +137,9 @@ public class GameService {
 
         log.info("🤖 계정명 : " + loginMember.getAccount());
 
+        Member participant = memberRepository.findByNickname(request.getParticipantNickname())
+                .orElseThrow(() -> new AppException(ErrorCode.MEMBER_NOT_FOUND));
+
         // Game Set 구성
         GameSet gameSet = GameSet.builder()
                 .gameStatus(GameStatus.GAME_START)
@@ -144,7 +147,8 @@ public class GameService {
                 .gameDay(1)
                 .gameSummary("")
                 .gameToken(0)
-                .member(loginMember)
+                .host(loginMember)
+                .participant(participant)
                 .build();
 
         GameSet savedGameSet = gameSetRepository.saveAndFlush(gameSet);


### PR DESCRIPTION
## 🌟(#27 ) 하나의 GameSetNo를 두 명의 유저가 보유하게 수정


## ✍️내용
-  unity가 GameStart 요청 시 하나의 Game에 참여한 유저 목록 함께 요청
- 하나의 GameSetNo를 두 명의 유저가 보유하게 수정

## 📸스크린샷


## 🎈참고사항
